### PR TITLE
Fix project media paths and add PostgreSQL/Express colors

### DIFF
--- a/DATA.json
+++ b/DATA.json
@@ -108,15 +108,15 @@
       "media": [
         {
           "type": "video",
-          "source": "/videos/project_m/preview-plang-m-1.mp4"
+          "source": "/videos/projects/preview-plang-m-1.mp4"
         },
         {
           "type": "video",
-          "source": "/videos/project_m/preview-plang-m-2.mp4"
+          "source": "/videos/projects/preview-plang-m-2.mp4"
         },
         {
           "type": "video",
-          "source": "/videos/project_m/preview-plang-m-3.mp4"
+          "source": "/videos/projects/preview-plang-m-3.mp4"
         }
       ]
     },
@@ -156,11 +156,11 @@
       "media": [
         {
           "type": "image",
-          "source": "/images/project_m/preview-markhub-1.jpg"
+          "source": "/images/projects/preview-markhub-1.jpg"
         },
         {
           "type": "image",
-          "source": "/images/project_m/preview-markhub-2.jpg"
+          "source": "/images/projects/preview-markhub-2.jpg"
         }
       ]
     },
@@ -200,11 +200,11 @@
       "media": [
         {
           "type": "image",
-          "source": "/images/project_m/preview-og-xyz-1.png"
+          "source": "/images/projects/preview-og-xyz-1.png"
         },
         {
           "type": "image",
-          "source": "/images/project_m/preview-og-xyz-2.png"
+          "source": "/images/projects/preview-og-xyz-2.png"
         }
       ]
     },
@@ -239,15 +239,15 @@
       "media": [
         {
           "type": "image",
-          "source": "/images/project_m/preview-og-3.png"
+          "source": "/images/projects/preview-og-3.png"
         },
         {
           "type": "image",
-          "source": "/images/project_m/preview-og-2.png"
+          "source": "/images/projects/preview-og-2.png"
         },
         {
           "type": "image",
-          "source": "/images/project_m/preview-og-7.png"
+          "source": "/images/projects/preview-og-7.png"
         }
       ]
     },
@@ -284,11 +284,11 @@
       "media": [
         {
           "type": "video",
-          "source": "/videos/project_m/preview-fold4-1.mp4"
+          "source": "/videos/projects/preview-fold4-1.mp4"
         },
         {
           "type": "video",
-          "source": "/videos/project_m/preview-fold4-2.mp4"
+          "source": "/videos/projects/preview-fold4-2.mp4"
         }
       ]
     },
@@ -336,11 +336,11 @@
       "media": [
         {
           "type": "video",
-          "source": "/videos/project_m/preview-fave-1.mp4"
+          "source": "/videos/projects/preview-fave-1.mp4"
         },
         {
           "type": "video",
-          "source": "/videos/project_m/preview-fave-2.mp4"
+          "source": "/videos/projects/preview-fave-2.mp4"
         }
       ]
     },
@@ -376,11 +376,11 @@
       "media": [
         {
           "type": "video",
-          "source": "/videos/project_m/preview-s22-2.mp4"
+          "source": "/videos/projects/preview-s22-2.mp4"
         },
         {
           "type": "video",
-          "source": "/videos/project_m/preview-s22-3.mp4"
+          "source": "/videos/projects/preview-s22-3.mp4"
         }
       ]
     },
@@ -418,11 +418,11 @@
       "media": [
         {
           "type": "video",
-          "source": "/videos/project_m/preview-fold3-2.mp4"
+          "source": "/videos/projects/preview-fold3-2.mp4"
         },
         {
           "type": "video",
-          "source": "/videos/project_m/preview-fold3-3.mp4"
+          "source": "/videos/projects/preview-fold3-3.mp4"
         }
       ]
     },
@@ -455,11 +455,11 @@
       "media": [
         {
           "type": "image",
-          "source": "/images/project_m/preview-jangsu-1.png"
+          "source": "/images/projects/preview-jangsu-1.png"
         },
         {
           "type": "image",
-          "source": "/images/project_m/preview-jangsu-2.png"
+          "source": "/images/projects/preview-jangsu-2.png"
         }
       ]
     },
@@ -498,11 +498,11 @@
       "media": [
         {
           "type": "image",
-          "source": "/images/project_m/preview-secureflare-1.png"
+          "source": "/images/projects/preview-secureflare-1.png"
         },
         {
           "type": "image",
-          "source": "/images/project_m/preview-secureflare-2.png"
+          "source": "/images/projects/preview-secureflare-2.png"
         }
       ]
     }

--- a/src/consts/index.ts
+++ b/src/consts/index.ts
@@ -21,5 +21,7 @@ export const LANGUAGE_COLORS = {
   Linux: "#f5f5f5",
   "Three.js": "#000000",
   "Gulp.js": "#cf4647",
-  GraphQL: "#f6009c"
+  GraphQL: "#f6009c",
+  PostgreSQL: "#336791",
+  Express: "#259dca"
 };


### PR DESCRIPTION
## Summary
- DATA.json still referenced `/images/project_m/` and `/videos/project_m/` even though `chore: clean up` (8079592) moved the files to `/images/projects/` and `/videos/projects/`. Only the recently added Outschool entry used the correct path, so its media rendered while every other project's media 404'd. Updated all paths to `projects/`.
- Added brand colors for **PostgreSQL** (`#336791`) and **Express** (`#259dca`) in `src/consts/index.ts` so the Outschool skill chips render with a color instead of being blank.

## Test plan
- [x] `npx vite build` succeeds
- [x] `npx vite` dev server returns 200 for the first asset of every project (Plang, Markhub, OG.xyz, OG, Fold4, Fave, S22, Fold3, Jangsu, Secureflare, Outschool)
- [ ] Visually verify on the deployed page that every project shows its images/videos and that PostgreSQL/Express chips have colored dots

https://claude.ai/code/session_01S6XSZQ565g6pjsqGU4rLSd

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6XSZQ565g6pjsqGU4rLSd)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added color support for GraphQL, PostgreSQL, and Express technologies to enhance project visualization and categorization.

* **Chores**
  * Updated project media asset file paths for improved content organization and delivery.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ykdhan/ykdhan.github.io/pull/12?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->