### PR TITLE
Polish copy and trim hero/footer meta

### DIFF
--- a/DATA.json
+++ b/DATA.json
@@ -1,9 +1,9 @@
 {
   "introduction": {
     "ko": [
-      "열정을 가지고 사람들에게 즐거움을 주고 기억에 남는 서비스를 만들고 있는 개발자입니다.",
-      "유익한 서비스를 제공하기 위해, 최신 트렌드를 따르며 사용자 경험(UX)과 사용자 인터페이스(UI)에 깊은 관심을 가지고 적극적으로 기여하고 있습니다",
-      "또한, 영향력 있는 개발자가 되기 위해, 가능한 모든 개발 분야의 지식과 경험을 쌓으려고 다양한 기회를 찾고 노력하고 있습니다."
+      "쓰는 사람에게 즐거움을 주고, 오래 기억에 남는 서비스를 만드는 걸 가장 좋아하는 개발자입니다.",
+      "더 좋은 서비스를 위해 최신 트렌드를 꾸준히 따라가고, 사용자 경험(UX)과 인터페이스(UI) 디테일에 특히 진심입니다.",
+      "더 영향력 있는 개발자가 되고 싶어, 한 분야에 머무르지 않고 새로운 영역에도 망설임 없이 뛰어들며 경험의 폭을 넓혀 왔습니다."
     ],
     "en": [
       "With great passion, I create memorable services that bring joy to people.",
@@ -28,7 +28,7 @@
       "languages": ["React", "TypeScript", "GraphQL", "PostgreSQL", "Express"],
       "contribution": {
         "ko": [
-          "React, TypeScript를 활용한 웹 어플리케이션 풀스택 개발",
+          "React, TypeScript를 활용한 웹 앱 풀스택 개발",
           "GraphQL을 활용한 API 설계 및 개발",
           "Express 기반 백엔드 서버 개발",
           "PostgreSQL을 활용한 데이터베이스 스키마 설계 및 데이터 모델링",
@@ -67,7 +67,7 @@
         "en": "Plang"
       },
       "description": {
-        "ko": "AI 개인맞춤 영어회화 모바일 어플리케이션",
+        "ko": "AI 맞춤형 영어회화 앱",
         "en": "AI-Driven English Conversation Mobile Application"
       },
       "languages": ["React", "React Native", "TypeScript", "Redux", "Redux Saga", "Ruby on Rails"],
@@ -122,13 +122,13 @@
         "en": "Markhub"
       },
       "description": {
-        "ko": "디자인 프로젝트를 위한 커뮤니케이션 서비스",
+        "ko": "디자인 협업을 위한 커뮤니케이션 서비스",
         "en": "Communication Software for Design Project"
       },
       "languages": ["Flutter", "GetX", "Firebase", "GraphQL"],
       "contribution": {
         "ko": [
-          "Flutter를 활용한 웹 어플리케이션 개발",
+          "Flutter를 활용한 웹 앱 개발",
           "GetX를 활용한 상태관리 및 라우팅",
           "Firebase, GraphQL을 활용한 데이터 통신",
           "Text Editor 모듈 개발",
@@ -210,13 +210,13 @@
         "en": "OG"
       },
       "description": {
-        "ko": "NFT 큐레이션 모바일 어플리케이션",
+        "ko": "NFT 큐레이션 앱",
         "en": "NFT Curation Mobile Application"
       },
       "languages": ["Flutter", "Firebase"],
       "contribution": {
         "ko": [
-          "사용해 보지 않은 Flutter를 도입하여 모바일 어플리케이션 개발",
+          "사용해 보지 않은 Flutter를 도입하여 모바일 앱 개발",
           "Metamask와 같은 Web3 지갑 연동",
           "3개월 내 AppStore, GooglePlay 베타 앱 출시"
         ],
@@ -461,11 +461,11 @@
         "en": "Secureflare Inc."
       },
       "title": {
-        "ko": "웹 모니터링 어플리케이션",
+        "ko": "웹 모니터링 앱",
         "en": "Web Monitoring Application"
       },
       "description": {
-        "ko": "Zabbix 기반 LG U+ 웹 모니터링 어플리케이션",
+        "ko": "Zabbix 기반 LG U+ 웹 모니터링 앱",
         "en": "LG U+ Web Monitoring Application with Zabbix"
       },
       "color": "#d31f32",

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -23,11 +23,6 @@ export default function Footer() {
           delay={0.05}
         />
 
-        <a className="footer-mail" href={`mailto:${SITE.email}`}>
-          <span className="line">{SITE.email}</span>
-          <span aria-hidden="true">↗</span>
-        </a>
-
         <Reveal delay={0.08} y={16}>
           <ContactForm />
         </Reveal>
@@ -40,7 +35,7 @@ export default function Footer() {
 
         <div className="footer-bottom">
           <span>
-            © {year} {SITE.name[locale]} — {t("rights")}
+            {year} {SITE.name[locale]}
           </span>
           <div className="footer-links">
             <a className="sticker" href={`mailto:${SITE.email}`}>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -15,7 +15,7 @@ export default function Hero() {
       <div className="container" style={{ position: "relative", zIndex: 1, width: "100%" }}>
         <Reveal className="hero-tag" y={16}>
           <span className="eyebrow">
-            {t("heroKicker")} · {STRINGS.nameFull[locale]}
+            {t("heroKicker")} · {new Date().getFullYear()} · {STRINGS.nameFull[locale]}
           </span>
         </Reveal>
 
@@ -30,7 +30,6 @@ export default function Hero() {
           </Reveal>
 
           <Reveal className="hero-meta" delay={0.35} y={16}>
-            <span className="ok">{t("heroOpen")}</span>
             <span>{t("heroBased")}</span>
             <span>
               © <b>YK</b> — {STRINGS.nameFull[locale]}

--- a/src/i18n/strings.ts
+++ b/src/i18n/strings.ts
@@ -6,14 +6,13 @@ export const STRINGS: Record<string, Dict> = {
   role: { ko: "풀스택 개발자", en: "Fullstack Developer" },
   nameFull: { ko: "한영광", en: "Youngkwang Han" },
 
-  // hero
-  heroKicker: { ko: "포트폴리오 · 2024", en: "Portfolio · 2024" },
+  // hero  (year is injected at runtime, name is appended in the component)
+  heroKicker: { ko: "포트폴리오", en: "Portfolio" },
   heroLede: {
-    ko: "사람들에게 *즐거움*을 주고 오래 *기억에 남는* 서비스를 만듭니다. 보이는 화면부터 보이지 않는 서버까지, 끝에서 끝까지 직접 짓습니다.",
+    ko: "쓰는 사람이 *즐겁고*, 오래 *기억에 남는* 서비스를 만듭니다. 눈에 보이는 화면부터 뒤에서 돌아가는 서버까지, 처음부터 끝까지 직접 만듭니다.",
     en: "I build products people *enjoy* and *remember* — from the pixels on screen to the servers behind them, end to end."
   },
-  heroBased: { ko: "거점 / 서울 · 원격", en: "Based / Seoul · Remote" },
-  heroOpen: { ko: "상태 / 협업 가능", en: "Status / Open to work" },
+  heroBased: { ko: "거점 / 원격", en: "Based / Remote" },
   scrollCue: { ko: "스크롤", en: "Scroll" },
 
   // about
@@ -21,44 +20,43 @@ export const STRINGS: Record<string, Dict> = {
   aboutTitle: { ko: "코드로\n분위기를\n만든다", en: "Building\nthe vibe\nwith code" },
   aboutCardTitle: { ko: "// 기본 정보", en: "// the basics" },
   factRole: { ko: "역할", en: "Role" },
-  factFocus: { ko: "관심", en: "Focus" },
+  factFocus: { ko: "관심사", en: "Focus" },
   factFocusVal: { ko: "UX · UI · 퍼포먼스", en: "UX · UI · Performance" },
   factStack: { ko: "주력", en: "Stack" },
   factStackVal: { ko: "React · TS · Node", en: "React · TS · Node" },
-  factMail: { ko: "연락", en: "Contact" },
+  factMail: { ko: "연락처", en: "Contact" },
 
   // skills
   skillsEyebrow: { ko: "기술 / 연장통", en: "Stack / the toolbox" },
   skillsTitle: { ko: "쓰는 도구들", en: "Tools of\nthe trade" },
   skillsNote: {
-    ko: "새로운 기술이라도 *빠르게 익혀* 현업에 적용합니다. 노트북에 붙은 스티커처럼 늘어나는 중.",
+    ko: "처음 보는 기술도 *빠르게 익혀서* 바로 실무에 씁니다. 노트북에 붙는 스티커처럼 계속 늘어나는 중.",
     en: "I pick up new tools *fast* and ship with them. The sticker collection keeps growing."
   },
 
   // projects
   worksEyebrow: { ko: "작업 / 골목 전시", en: "Selected work / the wall" },
   worksTitle: { ko: "만든 것들", en: "Things\nI've shipped" },
-  featured: { ko: "추천작", en: "Featured" },
+  featured: { ko: "대표작", en: "Featured" },
   viewLive: { ko: "보러가기", en: "View live" },
-  file: { ko: "파일", en: "File" },
+  file: { ko: "프로젝트", en: "PROJECT" },
 
   // footer
   footerEyebrow: { ko: "연락 / 한 잔 하면서", en: "Contact / let's talk" },
   footerCta: { ko: "재밌는 거\n같이\n만들어요", en: "Let's make\nsomething\nloud" },
   footerNote: {
-    ko: "협업, 채용, 그냥 인사도 환영이에요. *메일 주세요.*",
+    ko: "협업이든 채용이든, 그냥 인사라도 좋아요. 아래에 *한 줄 남겨주세요.*",
     en: "Collabs, gigs, or just a hello — *drop me a line.*"
   },
   backTop: { ko: "맨 위로", en: "Back to top" },
-  rights: { ko: "전부 직접 만듦", en: "Handmade, all of it" },
 
   // contact form
   contactPlaceholder: { ko: "메시지를 남겨주세요…", en: "Leave a quick message…" },
   contactSend: { ko: "전송", en: "Send" },
   contactSending: { ko: "보내는 중…", en: "Sending…" },
-  contactSent: { ko: "보냈어요! 곧 답장할게요 ✦", en: "Sent! I'll get back to you ✦" },
+  contactSent: { ko: "보냈어요! 곧 답장드릴게요 ✦", en: "Sent! I'll get back to you ✦" },
   contactError: {
-    ko: "전송이 안 됐어요. ykdhan@gmail.com 으로 부탁드려요.",
+    ko: "전송이 안 됐어요. ykdhan@gmail.com 으로 보내주세요.",
     en: "Couldn't send — email me at ykdhan@gmail.com instead."
   }
 };

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -687,11 +687,12 @@ html.lenis body {
 
 .project-index {
   font-family: var(--font-display);
-  font-size: clamp(40px, 7vw, 92px);
+  font-size: clamp(30px, 5vw, 62px);
   color: transparent;
   -webkit-text-stroke: 1.5px var(--line-strong);
   line-height: 0.8;
   margin-bottom: 6px;
+  white-space: nowrap;
 }
 .project-title {
   font-family: var(--font-display);
@@ -944,21 +945,9 @@ html.lenis body {
   font-family: var(--font-display-ko);
   font-weight: 900;
 }
-.footer-mail {
-  display: inline-flex;
-  align-items: center;
-  gap: 10px;
-  margin-top: 16px;
-  font-family: var(--font-display);
-  font-size: clamp(18px, 3.2vw, 32px);
-  text-transform: uppercase;
-  color: var(--neon);
-  position: relative;
-}
-
 /* contact form (Slack webhook) */
 .contact {
-  margin-top: 24px;
+  margin-top: clamp(28px, 5vw, 44px);
   max-width: 540px;
 }
 .contact-form {
@@ -1040,17 +1029,6 @@ html.lenis body {
   to {
     transform: rotate(360deg);
   }
-}
-.footer-mail .line {
-  background-image: linear-gradient(var(--neon), var(--neon));
-  background-size: 0% 2px;
-  background-position: 0 100%;
-  background-repeat: no-repeat;
-  transition: background-size 0.35s ease;
-  padding-bottom: 4px;
-}
-.footer-mail:hover .line {
-  background-size: 100% 2px;
 }
 .footer-bottom {
   margin-top: clamp(48px, 8vw, 88px);
@@ -1175,29 +1153,6 @@ html.lenis body {
   text-transform: uppercase;
   letter-spacing: 0.16em;
   color: var(--ink-2);
-}
-.hero-meta .ok {
-  display: inline-flex;
-  align-items: center;
-  gap: 7px;
-}
-.hero-meta .ok::before {
-  content: "";
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background: var(--neon);
-  box-shadow: 0 0 10px var(--neon);
-  animation: pulse 1.6s ease-in-out infinite;
-}
-@keyframes pulse {
-  0%,
-  100% {
-    opacity: 1;
-  }
-  50% {
-    opacity: 0.3;
-  }
 }
 @media (max-width: 600px) {
   .hide-sm {


### PR DESCRIPTION
Follow-up tweaks on top of the redesign (#14), focused on copy and a few meta details.

## Changes

### Hero
- Remove the **"Status / Open to work"** line (and its pulsing dot).
- **"Based / Seoul · Remote" → "Based / Remote"**.
- Kicker year is now derived from `new Date().getFullYear()` instead of a hardcoded `2024`, so it stays current (shows 2026 today).

### Footer
- Remove the large email link that sat above the message box (the Slack message form + the Email sticker in the bottom row still cover contact).
- Simplify the bottom credit to just **`<year> <name>`** (e.g. `2026 한영광` / `2026 YK`) — no `©`, no tagline.

### Projects
- Project label **"FILE NN" → "PROJECT NN" / "프로젝트 NN"**, with an index sizing fix so the longer label never wraps.

### Korean copy
- Natural-voice pass across the site: hero lede, the about/bio statements, the skills & footer notes, and project descriptions.
- Normalized **`어플리케이션` → `앱`** throughout `DATA.json`.

English copy is unchanged. Verified with `npm run build` + `tsc --noEmit`, and visually checked hero / project / footer in both KO and EN, desktop and mobile.

https://claude.ai/code/session_015RD4jSa2YB2KJHu3pScdwq

---
_Generated by [Claude Code](https://claude.ai/code/session_015RD4jSa2YB2KJHu3pScdwq)_