### PR TITLE
Simplify hero/section copy and trim nav

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -28,13 +28,6 @@ export default function Hero() {
           <Reveal className="hero-lede" delay={0.25}>
             <Marked text={t("heroLede")} />
           </Reveal>
-
-          <Reveal className="hero-meta" delay={0.35} y={16}>
-            <span>{t("heroBased")}</span>
-            <span>
-              © <b>YK</b> — {STRINGS.nameFull[locale]}
-            </span>
-          </Reveal>
         </div>
       </div>
 

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from "react";
 import { useLocale } from "../i18n/LocaleContext";
 import { useT } from "../i18n/strings";
-import { SITE } from "../data/portfolio";
 import { scrollToId } from "../hooks/useSmoothScroll";
 import GlitchText from "./GlitchText";
 
@@ -52,10 +51,6 @@ export default function Nav() {
             EN
           </button>
         </div>
-
-        <a className="sticker solid hide-sm" href={`mailto:${SITE.email}`}>
-          ✉ {locale === "ko" ? "메일" : "Email"}
-        </a>
       </div>
     </nav>
   );

--- a/src/components/Reveal.tsx
+++ b/src/components/Reveal.tsx
@@ -99,6 +99,8 @@ export function RevealText({
 
 /** Renders text, wrapping any *starred* phrase in a highlight that sweeps in. */
 export function Marked({ text }: { text: string }) {
+  // Split on the *highlight* markup, keeping the delimiters, then turn any
+  // literal newline inside a plain segment into a <br/>.
   const parts = text.split(/(\*[^*]+\*)/g);
   return (
     <>
@@ -108,7 +110,14 @@ export function Marked({ text }: { text: string }) {
             {p.slice(1, -1)}
           </span>
         ) : (
-          <span key={i}>{p}</span>
+          <span key={i}>
+            {p.split("\n").map((line, j, arr) => (
+              <span key={j}>
+                {line}
+                {j < arr.length - 1 && <br />}
+              </span>
+            ))}
+          </span>
         )
       )}
     </>

--- a/src/i18n/strings.ts
+++ b/src/i18n/strings.ts
@@ -9,14 +9,14 @@ export const STRINGS: Record<string, Dict> = {
   // hero  (year is injected at runtime, name is appended in the component)
   heroKicker: { ko: "포트폴리오", en: "Portfolio" },
   heroLede: {
-    ko: "쓰는 사람이 *즐겁고*, 오래 *기억에 남는* 서비스를 만듭니다. 눈에 보이는 화면부터 뒤에서 돌아가는 서버까지, 처음부터 끝까지 직접 만듭니다.",
+    ko: "쓰는 사람이 *즐겁고*, 오래 *기억에 남는* 서비스를 만듭니다\n눈에 보이는 화면부터 뒤에서 돌아가는 서버까지",
     en: "I build products people *enjoy* and *remember* — from the pixels on screen to the servers behind them, end to end."
   },
   heroBased: { ko: "거점 / 원격", en: "Based / Remote" },
   scrollCue: { ko: "스크롤", en: "Scroll" },
 
   // about
-  aboutEyebrow: { ko: "소개 / 누구냐면", en: "About / who's this" },
+  aboutEyebrow: { ko: "소개", en: "About / who's this" },
   aboutTitle: { ko: "코드로\n분위기를\n만든다", en: "Building\nthe vibe\nwith code" },
   aboutCardTitle: { ko: "// 기본 정보", en: "// the basics" },
   factRole: { ko: "역할", en: "Role" },
@@ -27,7 +27,7 @@ export const STRINGS: Record<string, Dict> = {
   factMail: { ko: "연락처", en: "Contact" },
 
   // skills
-  skillsEyebrow: { ko: "기술 / 연장통", en: "Stack / the toolbox" },
+  skillsEyebrow: { ko: "스택", en: "Stack / the toolbox" },
   skillsTitle: { ko: "쓰는 도구들", en: "Tools of\nthe trade" },
   skillsNote: {
     ko: "처음 보는 기술도 *빠르게 익혀서* 바로 실무에 씁니다. 노트북에 붙는 스티커처럼 계속 늘어나는 중.",
@@ -35,14 +35,14 @@ export const STRINGS: Record<string, Dict> = {
   },
 
   // projects
-  worksEyebrow: { ko: "작업 / 골목 전시", en: "Selected work / the wall" },
+  worksEyebrow: { ko: "프로젝트", en: "Selected work / the wall" },
   worksTitle: { ko: "만든 것들", en: "Things\nI've shipped" },
   featured: { ko: "대표작", en: "Featured" },
   viewLive: { ko: "보러가기", en: "View live" },
   file: { ko: "프로젝트", en: "PROJECT" },
 
   // footer
-  footerEyebrow: { ko: "연락 / 한 잔 하면서", en: "Contact / let's talk" },
+  footerEyebrow: { ko: "연락", en: "Contact / let's talk" },
   footerCta: { ko: "재밌는 거\n같이\n만들어요", en: "Let's make\nsomething\nloud" },
   footerNote: {
     ko: "협업이든 채용이든, 그냥 인사라도 좋아요. 아래에 *한 줄 남겨주세요.*",

--- a/src/i18n/strings.ts
+++ b/src/i18n/strings.ts
@@ -30,7 +30,7 @@ export const STRINGS: Record<string, Dict> = {
   skillsEyebrow: { ko: "스택", en: "Stack / the toolbox" },
   skillsTitle: { ko: "쓰는 도구들", en: "Tools of\nthe trade" },
   skillsNote: {
-    ko: "처음 보는 기술도 *빠르게 익혀서* 바로 실무에 씁니다. 노트북에 붙는 스티커처럼 계속 늘어나는 중.",
+    ko: "처음 보는 기술도 *빠르게 익혀서* 바로 실무에 씁니다",
     en: "I pick up new tools *fast* and ship with them. The sticker collection keeps growing."
   },
 

--- a/src/i18n/strings.ts
+++ b/src/i18n/strings.ts
@@ -51,7 +51,10 @@ export const STRINGS: Record<string, Dict> = {
   backTop: { ko: "맨 위로", en: "Back to top" },
 
   // contact form
-  contactPlaceholder: { ko: "메시지를 남겨주세요…", en: "Leave a quick message…" },
+  contactPlaceholder: {
+    ko: "연락처와 함께 메시지를 남겨주세요…",
+    en: "Your message + how to reach you…"
+  },
   contactSend: { ko: "전송", en: "Send" },
   contactSending: { ko: "보내는 중…", en: "Sending…" },
   contactSent: { ko: "보냈어요! 곧 답장드릴게요 ✦", en: "Sent! I'll get back to you ✦" },


### PR DESCRIPTION
## What changed

**Hero (first section)**
- Removed the `거점 / 원격` + `© YK — 한영광` meta line
- Reflowed the Korean lede onto two lines and dropped the trailing clause:
  > 쓰는 사람이 *즐겁고*, 오래 *기억에 남는* 서비스를 만듭니다
  > 눈에 보이는 화면부터 뒤에서 돌아가는 서버까지
- `Marked` now renders `\n` as `<br/>` so multi-line copy works

**Nav header**
- Removed the `✉ 메일` button (and the now-unused `SITE` import)

**Section eyebrows (Korean)**
- `소개 / 누구냐면` → `소개`
- `작업 / 골목 전시` → `프로젝트`
- `기술 / 연장통` → `스택`
- `연락 / 한 잔 하면서` → `연락`

**Skills note (Korean)**
- Trimmed to a single sentence: `처음 보는 기술도 빠르게 익혀서 바로 실무에 씁니다`

**Contact form placeholder**
- Now prompts senders to include contact info so replies are possible

English copy was left unchanged. `npm run build` passes.

https://claude.ai/code/session_01QDKSWERHZu8TQVfjwSCQQW

---
_Generated by [Claude Code](https://claude.ai/code/session_01QDKSWERHZu8TQVfjwSCQQW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **UI/UX Updates**
  * Redesigned hero section with copyright attribution removed.
  * Simplified navigation by removing email contact link.
  * Improved text rendering with enhanced line break support.
  * Updated localized copy across hero, skills, projects, footer, and contact sections.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ykdhan/ykdhan.github.io/pull/16?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->